### PR TITLE
Remove duplicated code.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,8 +39,8 @@ task configure_state: [:validate_environment, :local_state_check, :purge_remote_
   region      = 'eu-west-1'
   bucket_name = "govuk-terraform-state-#{deploy_env}"
 
-  # todo either or?
   args = []
+  args << 'terraform remote config'
   args << '-backend=s3'
   args << '-backend-config="acl=private"'
   args << "-backend-config='bucket=#{bucket_name}'"
@@ -48,40 +48,29 @@ task configure_state: [:validate_environment, :local_state_check, :purge_remote_
   args << '-backend-config="key=terraform.tfstate"'
   args << "-backend-config='region=#{region}'"
 
-  value = `terraform remote config #{args.join(' ')}`
-  puts value
-
-  cmd  = 'terraform remote config '
-  cmd << ' -backend=s3 '
-  cmd << ' -backend-config="acl=private" '
-  cmd << " -backend-config='bucket=#{bucket_name}' "
-  cmd << ' -backend-config="encrypt=true"'
-  cmd << ' -backend-config="key=terraform.tfstate" '
-  cmd << " -backend-config='region=#{region}' "
-
-  system(cmd)
+  system(args.join(' '))
 end
 
 
 desc 'create and display the resource graph'
 task :graph do
   # todo  - does this need plan / apply to have been run
-  `terraform graph | dot -Tpng > graph.png`
-  `open graph.png`
+  system('terraform graph | dot -Tpng > graph.png')
+  system('open graph.png')
 end
 
 
 desc 'Apply the terraform resources'
 task apply: [:configure_state] do
-  `terraform apply -var-file=#{deploy_env}.tfvars`
+  system("terraform apply -var-file=#{deploy_env}.tfvars")
 end
 
 
 desc 'Show the plan'
 task plan: [:configure_state] do
-  `terraform plan -var-file=#{deploy_env}.tfvars`
+  system("terraform plan -var-file=#{deploy_env}.tfvars")
 end
 
 def deploy_env
-  return ENV['DEPLOY_ENV']
+  ENV['DEPLOY_ENV']
 end


### PR DESCRIPTION
We have chosen to use an array to buld the command, not a string
and so we can now remove the dead code. Also use `system` not backticks.
