### PR TITLE
Extract UKTT bucket creation code to a project

### DIFF
--- a/production.tfvars
+++ b/production.tfvars
@@ -1,2 +1,1 @@
 environment = "production"
-uktt_data_enabled = "1"

--- a/projects/uktt_data/README.tf
+++ b/projects/uktt_data/README.tf
@@ -1,0 +1,3 @@
+# UK Trade Tarrif Data Buckets
+
+This is an AWS S3 backup location for the UK Trade Tarrif seed data.

--- a/projects/uktt_data/resources/production/main.tf
+++ b/projects/uktt_data/resources/production/main.tf
@@ -1,7 +1,3 @@
-variable "uktt_data_enabled" {
-    default = "0"
-}
-
 variable "uktt_data_bucket_name" {
     type = "string"
     default = "govuk-uktt-data"
@@ -10,7 +6,6 @@ variable "uktt_data_bucket_name" {
 resource "aws_s3_bucket" "uktt_data_bucket" {
     acl = "private"
     bucket = "${var.uktt_data_bucket_name}-${var.environment}"
-    count = "${var.uktt_data_enabled}"
     versioning {
       enabled = true
     }


### PR DESCRIPTION
The resources required to create the UKTT bucket are quite isolated and
can be treated as a distinct unit of code so it's worth extracting them.
