### PR TITLE
Add packer config

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -1,0 +1,5 @@
+# Packer templates for building machine images
+
+Set environment variables for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+
+Run `packer build ami.json` from this directory.

--- a/packer/ami.json
+++ b/packer/ami.json
@@ -1,0 +1,13 @@
+{
+  "variables": {},
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "ami_name": "govuk-trusty-1404-{{isotime \"2006-01-02T1504\"}}",
+      "instance_type": "t2.micro",
+      "region": "eu-west-1",
+      "source_ami": "ami-b0c379c3",
+      "ssh_username": "ubuntu"
+    }
+  ]
+}

--- a/packer/ami.json
+++ b/packer/ami.json
@@ -9,5 +9,11 @@
       "source_ami": "ami-b0c379c3",
       "ssh_username": "ubuntu"
     }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "script": "scripts/provision.sh"
+    }
   ]
 }

--- a/packer/scripts/provision.sh
+++ b/packer/scripts/provision.sh
@@ -1,0 +1,11 @@
+source /etc/lsb-release
+
+PUPPET_DEB=puppetlabs-release-${DISTRIB_CODENAME}.deb
+wget https://apt.puppetlabs.com/${PUPPET_DEB}
+sudo dpkg -i ${PUPPET_DEB}
+rm -f ${PUPPET_DEB}
+
+sudo apt-get update
+
+sudo apt-get -y install build-essential ruby1.9.3 puppet='3.8.5-*' puppet-common='3.8.5-*'
+sudo service puppet stop


### PR DESCRIPTION
These machines will be backed by Elastic Block Store (EBS) for use in EC2.

The source AMI is from https://cloud-images.ubuntu.com/locator/ec2/ and has the following properties:

- eu-west-1
- 14.04 LTS Trusty
- amd64
- [HVM (hardware virtual machine) instead of PV (paravirtual)][1]
  because more EC2 machine types seem to be available for HVM images

The name of the source AMI in the AWS console is: `ubuntu/images/hvm/ubuntu-trusty-14.04-amd64-server-20160314`

[1]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html

---

We've added a basic provisioning script which installs our version of Puppet onto the AMI.

We also install build-essential because it's required for lots of things (eg make) and is already present on all of our machines.

We should potentially use our APT mirror to install Puppet rather than adding a DEB from `apt.puppetlabs.com`.