### PR TITLE
Make distinct WAL-E S3 buckets

### DIFF
--- a/projects/wal-e_backups_api-postgresql/resources/storage_and_access.tf
+++ b/projects/wal-e_backups_api-postgresql/resources/storage_and_access.tf
@@ -1,8 +1,8 @@
 module "paired_user" {
     source = "../../../modules/paired_user"
 
-    bucket_name = "govuk-wale-backups"
+    bucket_name = "govuk-wal-e_backups_api-postgresql"
     environment = "${var.environment}"
     team        = "Infrastructure"
-    username    = "govuk-wale-backups"
+    username    = "govuk-wal-e_backups_api-postgresql"
 }

--- a/projects/wal-e_backups_postgresql/resources/storage_and_access.tf
+++ b/projects/wal-e_backups_postgresql/resources/storage_and_access.tf
@@ -1,0 +1,8 @@
+module "paired_user" {
+    source = "../../../modules/paired_user"
+
+    bucket_name = "govuk-wal-e_backups_postgresql"
+    environment = "${var.environment}"
+    team        = "Infrastructure"
+    username    = "govuk-wal-e_backups_postgresql"
+}

--- a/projects/wal-e_backups_transition-postgresql/resources/storage_and_access.tf
+++ b/projects/wal-e_backups_transition-postgresql/resources/storage_and_access.tf
@@ -1,0 +1,8 @@
+module "paired_user" {
+    source = "../../../modules/paired_user"
+
+    bucket_name = "govuk-wal-e_backups_transition-postgresql"
+    environment = "${var.environment}"
+    team        = "Infrastructure"
+    username    = "govuk-wal-e_backups_transition-postgresql"
+}


### PR DESCRIPTION
There are three instances of PostgreSQL in the stack which will need backing up. This makes three distinct WAL-E buckets for each one to use.