### PR TITLE
Add S3 buckets for mysql_xtrabackups

### DIFF
--- a/projects/mysql_xtrabackups/resources/storage_and_access.tf
+++ b/projects/mysql_xtrabackups/resources/storage_and_access.tf
@@ -1,0 +1,8 @@
+module "paired_user" {
+    source = "../../../modules/paired_user"
+
+    bucket_name = "govuk-mysql-xtrabackups"
+    environment = "${var.environment}"
+    team        = "Infrastructure"
+    username    = "govuk-mysql-xtrabackups"
+}


### PR DESCRIPTION
This creates buckets to allow streaming MySQL backups.

Please note a bucket has already been deployed in the test environment.