### PR TITLE
Make AMIs public

### DIFF
--- a/packer/ami.json
+++ b/packer/ami.json
@@ -6,6 +6,7 @@
   "builders": [
     {
       "type": "amazon-ebs",
+      "ami_groups": ["all"],
       "ami_name": "govuk-trusty-1404-{{isotime \"2006-01-02T1504\"}}",
       "iam_instance_profile": "VPCLockDown",
       "instance_type": "t2.micro",


### PR DESCRIPTION
Our AMIs don't contain any secret information so we should make them public for now.

> A list of groups that have access to launch the resulting AMI(s).
> By default no groups have permission to launch the AMI. all will
> make the AMI publicly accessible. AWS currently doesn't accept
> any value other than "all".