### PR TITLE
sets up S3 bucket for transition logs

### DIFF
--- a/projects/transition-logs-backups/resources/storage_and_access.tf
+++ b/projects/transition-logs-backups/resources/storage_and_access.tf
@@ -1,0 +1,8 @@
+module "private_s3_bucket" {
+    source = "../../../modules/private_s3_bucket"
+
+    bucket_name = "govuk-transition-logs"
+    environment = "${var.environment}"
+    team        = "Infrastructure"
+    username    = "govuk-transition-logs"
+}


### PR DESCRIPTION
We want the lowest-cost storage class for these logs as they will
seldomly be accessed, such as in a DR scenario. Unfortunately
terraform does not currently support lifecycle configuration, so
we will need to manage this aspect manually.