### PR TITLE
Create bucket for whitehall attachments

### DIFF
--- a/modules/private_s3_bucket/README.md
+++ b/modules/private_s3_bucket/README.md
@@ -1,0 +1,8 @@
+# Private_S3_Bucket
+
+## Introduction
+
+This creates an S3 bucket which has a read-write user and no public access.
+
+If you're creating a bucket which will hold any sensitive data it is recommended
+to use this module.

--- a/modules/private_s3_bucket/main.tf
+++ b/modules/private_s3_bucket/main.tf
@@ -1,0 +1,56 @@
+variable "bucket_name" {
+    type = "string"
+}
+
+variable "environment" {
+    type = "string"
+}
+
+variable "team" {
+    type = "string"
+}
+
+variable "username" {
+    type = "string"
+}
+
+
+resource "template_file" "readwrite_policy_file" {
+  template = "${file("${path.module}/templates/readwrite_policy.tpl")}"
+
+  vars {
+    bucket_name = "${var.bucket_name}"
+    environment = "${var.environment}"
+  }
+}
+
+
+
+resource "aws_s3_bucket" "bucket" {
+    bucket = "${var.bucket_name}-${var.environment}"
+
+    tags {
+        Environment = "${var.environment}"
+        Team = "${var.team}"
+    }
+}
+
+
+
+resource "aws_iam_policy" "readwrite_policy" {
+    name = "${var.bucket_name}_${var.username}-policy"
+    description = "${var.bucket_name} allows writes"
+    policy = "${template_file.readwrite_policy_file.rendered}"
+}
+
+
+
+resource "aws_iam_user" "iam_user" {
+    name = "${var.username}"
+}
+
+resource "aws_iam_policy_attachment" "iam_policy_attachment" {
+    name = "${var.bucket_name}_${var.username}_attachment_policy"
+    users = ["${aws_iam_user.iam_user.name}"]
+    policy_arn = "${aws_iam_policy.readwrite_policy.arn}"
+}

--- a/modules/private_s3_bucket/templates/readwrite_policy.tpl
+++ b/modules/private_s3_bucket/templates/readwrite_policy.tpl
@@ -1,0 +1,29 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListBucketVersions"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}-${environment}"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:AbortMultipartUpload",
+        "s3:ListMultipartUploadParts"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}-${environment}/*"
+      ]
+    }
+  ]
+}

--- a/projects/govuk_attachments/resources/storage_and_access.tf
+++ b/projects/govuk_attachments/resources/storage_and_access.tf
@@ -1,0 +1,8 @@
+module "private_s3_bucket" {
+    source = "../../../modules/private_s3_bucket"
+
+    bucket_name = "govuk-attachments"
+    environment = "${var.environment}"
+    team        = "Infrastructure"
+    username    = "govuk-attachments"
+}


### PR DESCRIPTION
This is used to back-up whitehall attachments. 

Ticket: https://trello.com/c/DTByYmW1/51-sync-whitehall-attachments-to-s3
Related: https://github.com/alphagov/govuk-puppet/pull/4336