### PR TITLE
Allow listing of the public buckets

### DIFF
--- a/modules/paired_user/templates/readonly_policy.tpl
+++ b/modules/paired_user/templates/readonly_policy.tpl
@@ -2,6 +2,12 @@
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Principal": "*",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::${bucket_name}-${environment}"
+    },
+    {
       "Sid": "Allow public read-only access",
       "Effect": "Allow",
       "Principal": "*",


### PR DESCRIPTION
Not allowing this makes the public nature a little pointless as you
require an exact object name for anything to work.