### PR TITLE
Add env-sync RO user

### DIFF
--- a/projects/wal-e_backups_transition-postgresql/resources/production/env_sync_user.tf
+++ b/projects/wal-e_backups_transition-postgresql/resources/production/env_sync_user.tf
@@ -1,0 +1,26 @@
+resource "aws_iam_user" "env_sync" {
+    name = "govuk-transition-postgresql-env-sync"
+}
+
+
+resource "aws_iam_user_policy" "env-sync-policy" {
+    name = "govuk-wal-e-backups-transition-postgresql_env-sync-policy"
+    user = "${aws_iam_user.env_sync.name}"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::govuk-wal-e-backups-transition-postgresql-${var.environment}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::govuk-wal-e-backups-transition-postgresql-${var.environment}/*"
+    }
+  ]
+}
+EOF
+}


### PR DESCRIPTION
This adds a read-only user to be used for environment syncs. It needs to be in Production only as this is the only environment that we wish to sync from.

I've tried to keep this in line with how we do things but I don't think I've got it quite right so will probably need some guidance. 