### PR TITLE
Add env sync user for attachments

### DIFF
--- a/projects/govuk_attachments/resources/production/env_sync_user.tf
+++ b/projects/govuk_attachments/resources/production/env_sync_user.tf
@@ -1,0 +1,26 @@
+resource "aws_iam_user" "env_sync" {
+    name = "govuk-attachments-env-sync"
+}
+
+
+resource "aws_iam_user_policy" "env-sync-policy" {
+    name = "govuk-attachments_env-sync-policy"
+    user = "${aws_iam_user.env_sync.name}"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::govuk-attachments-${var.environment}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::govuk-attachments-${var.environment}/*"
+    }
+  ]
+}
+EOF
+}


### PR DESCRIPTION
This adds a read-only user in Production only for use with environment syncing. The user needs to be able to use s3cmd sync to seed the files and then download into the Staging and/or Integration environment.