### PR TITLE
Add option for versioning

### DIFF
--- a/modules/private_s3_bucket/main.tf
+++ b/modules/private_s3_bucket/main.tf
@@ -14,6 +14,11 @@ variable "username" {
     type = "string"
 }
 
+variable "versioning" {
+    type = "string"
+    default = "false"
+}
+
 
 resource "template_file" "readwrite_policy_file" {
   template = "${file("${path.module}/templates/readwrite_policy.tpl")}"
@@ -32,6 +37,10 @@ resource "aws_s3_bucket" "bucket" {
     tags {
         Environment = "${var.environment}"
         Team = "${var.team}"
+    }
+
+    versioning {
+        enabled = "${var.versioning}"
     }
 }
 

--- a/projects/govuk_attachments/resources/storage_and_access.tf
+++ b/projects/govuk_attachments/resources/storage_and_access.tf
@@ -5,4 +5,5 @@ module "private_s3_bucket" {
     environment = "${var.environment}"
     team        = "Infrastructure"
     username    = "govuk-attachments"
+    versioning  = "true"
 }


### PR DESCRIPTION
This adds an option for versioning an S3 bucket in a module, and adds an example use case within a project.

Note: not sure if this actually should be written as a string or a boolean, will test. 

As per the docs here https://www.terraform.io/docs/providers/aws/r/s3_bucket.html