### PR TITLE
Add versioning to lambda bucket

### DIFF
--- a/projects/lambda_app_bucket/resources/s3-buckets.tf
+++ b/projects/lambda_app_bucket/resources/s3-buckets.tf
@@ -5,4 +5,5 @@ module "lambda_app_bucket" {
     environment = "${var.environment}"
     team        = "Infrastructure"
     username    = "govuk-lambda-applications"
+    versioning  = "true"
 }


### PR DESCRIPTION
Code will change for the lambda function so we want to ensure we can
roll back to older versions in the S3 bucket.