### PR TITLE
Fix s3_key for Lambda function source

### DIFF
--- a/projects/email_alert_notifications/resources/email_alert_notifications.tf
+++ b/projects/email_alert_notifications/resources/email_alert_notifications.tf
@@ -56,7 +56,7 @@ resource "aws_iam_role_policy" "write_to_logs" {
 
 resource "aws_lambda_function" "rename_email_files_with_request_id"{
   s3_bucket = "${var.lambda_bucket}-${var.environment}"
-  s3_key="${var.LAMBDA_FILENAME}"
+  s3_key="email_alert_notifications/${var.LAMBDA_FILENAME}"
   s3_object_version="${var.LAMBDA_VERSIONID}"
   function_name = "rename_email_files_with_request_id"
   role = "${aws_iam_role.lambda_execute_and_write_to_email_alert_bucket.arn}"


### PR DESCRIPTION
This key is specific to the fact this is an email alert notification Lambda function.

We could pass this bit in as part of LAMBDA_FILENAME but I'm not sure it will ever change.