### PR TITLE
Update permissions of RW user

### DIFF
--- a/modules/private_s3_bucket/templates/readwrite_policy.tpl
+++ b/modules/private_s3_bucket/templates/readwrite_policy.tpl
@@ -16,7 +16,10 @@
     {
       "Action": [
         "s3:GetObject",
+        "s3:GetObjectACL",
         "s3:PutObject",
+        "s3:PutObjectACL",
+        "S3:DeleteObject",
         "s3:AbortMultipartUpload",
         "s3:ListMultipartUploadParts"
       ],


### PR DESCRIPTION
We have some functions which moves stuff around in buckets using the
private_s3_bucket module. It seems that without some permissions the
user is unable to do stuff like move objects around and (more obviously)
delete objects for the move. I tested manually and it seems the ACL
permissions are required.

/cc @deanwilson