### PR TITLE
Add Mongodb daily backup S3 bucket

### DIFF
--- a/projects/mongodb-backup-s3/resources/storage_and_access.tf
+++ b/projects/mongodb-backup-s3/resources/storage_and_access.tf
@@ -1,8 +1,18 @@
-module "paired_user" {
-    source = "../../../modules/paired_user"
+module "mongodb_s3_backup" {
+    source = "../../../modules/private_s3_bucket"
 
     bucket_name = "govuk-mongodb-backup-s3"
     environment = "${var.environment}"
     team        = "Infrastructure"
     username    = "govuk-mongodb-backup-s3"
 }
+
+module "mongodb_s3_daily_backpup" {
+    source = "../../../modules/private_s3_bucket"
+
+    bucket_name = "govuk-mongodb-daily-backup-s3"
+    environment = "${var.environment}"
+    team        = "Infrastructure"
+    username    = "govuk-mongodb-daily-backup-s3"
+}
+


### PR DESCRIPTION
Some slight refactoring so that we're using the private module policy for our mongo backups in S3. Added a bucket for mongo daily backups.