### PR TITLE
One user two buckets for Mongo S3 backups

### DIFF
--- a/projects/mongodb-backup-s3/resources/storage_and_access.tf
+++ b/projects/mongodb-backup-s3/resources/storage_and_access.tf
@@ -1,18 +1,77 @@
-module "mongodb_s3_backup" {
-    source = "../../../modules/private_s3_bucket"
-
-    bucket_name = "govuk-mongodb-backup-s3"
-    environment = "${var.environment}"
-    team        = "Infrastructure"
-    username    = "govuk-mongodb-backup-s3"
+variable "bucket_name" {
+    type = "string"
+    default = "govuk-mongodb-backup-s3"
 }
 
-module "mongodb_s3_daily_backpup" {
-    source = "../../../modules/private_s3_bucket"
-
-    bucket_name = "govuk-mongodb-daily-backup-s3"
-    environment = "${var.environment}"
-    team        = "Infrastructure"
-    username    = "govuk-mongodb-daily-backup-s3"
+variable "team" {
+    type = "string"
+    default = "Infrastructure"
 }
 
+variable "username" {
+    type = "string"
+    default = "govuk-mongodb-backup-s3"
+}
+
+variable "versioning" {
+    type = "string"
+    default = "true"
+}
+
+
+resource "template_file" "readwrite_policy_file" {
+  template = "${file("projects/mongodb-backup-s3/resources/templates/readwrite_policy.tpl")}"
+
+  vars {
+    bucket_name = "${var.bucket_name}"
+    environment = "${var.environment}"
+  }
+}
+
+
+
+resource "aws_s3_bucket" "govuk-mongodb-backup-s3" {
+    bucket = "${var.bucket_name}-${var.environment}"
+
+    tags {
+        Environment = "${var.environment}"
+        Team = "${var.team}"
+    }
+
+    versioning {
+        enabled = "${var.versioning}"
+    }
+}
+
+
+
+resource "aws_s3_bucket" "govuk-mongodb-backup-s3-daily" {
+    bucket = "${var.bucket_name}-daily-${var.environment}"
+
+    tags {
+        Environment = "${var.environment}"
+        Team = "${var.team}"
+    }
+
+    versioning {
+        enabled = "${var.versioning}"
+    }
+}
+
+resource "aws_iam_policy" "readwrite_policy" {
+    name = "${var.bucket_name}_${var.username}-policy"
+    description = "${var.bucket_name} allows writes"
+    policy = "${template_file.readwrite_policy_file.rendered}"
+}
+
+
+
+resource "aws_iam_user" "iam_user" {
+    name = "${var.username}"
+}
+
+resource "aws_iam_policy_attachment" "iam_policy_attachment" {
+    name = "${var.bucket_name}_${var.username}_attachment_policy"
+    users = ["${aws_iam_user.iam_user.name}"]
+    policy_arn = "${aws_iam_policy.readwrite_policy.arn}"
+}

--- a/projects/mongodb-backup-s3/resources/templates/readwrite_policy.tpl
+++ b/projects/mongodb-backup-s3/resources/templates/readwrite_policy.tpl
@@ -1,0 +1,34 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListBucketVersions"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}-${environment}",
+        "arn:aws:s3:::${bucket_name}-daily-${environment}"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetObject",
+        "s3:GetObjectACL",
+        "s3:PutObject",
+        "s3:PutObjectACL",
+        "S3:DeleteObject",
+        "s3:AbortMultipartUpload",
+        "s3:ListMultipartUploadParts"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}-${environment}/*",
+        "arn:aws:s3:::${bucket_name}-daily-${environment}/*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
For Mongo backups to S3 we have short term daily backups and a different bucket for daily longer term backups.

This adds the code to create two buckets that are owned by a single user.