### PR TITLE
Enable lifecycles in buckets

### DIFF
--- a/modules/private_s3_bucket/main.tf
+++ b/modules/private_s3_bucket/main.tf
@@ -19,6 +19,11 @@ variable "versioning" {
     default = "false"
 }
 
+variable "lifecycle" {
+    type = "string"
+    default = "false"
+}
+
 
 resource "template_file" "readwrite_policy_file" {
   template = "${file("${path.module}/templates/readwrite_policy.tpl")}"
@@ -41,6 +46,23 @@ resource "aws_s3_bucket" "bucket" {
 
     versioning {
         enabled = "${var.versioning}"
+    }
+
+    lifecycle_rule {
+        prefix = ""
+        enabled = "${var.lifecycle}"
+
+        noncurrent_version_transition {
+            days = 30
+            storage_class = "STANDARD_IA"
+        }
+        noncurrent_version_transition {
+            days = 60
+            storage_class = "GLACIER"
+        }
+        noncurrent_version_expiration {
+            days = 90
+        }
     }
 }
 

--- a/projects/mongodb-backup-s3/resources/storage_and_access.tf
+++ b/projects/mongodb-backup-s3/resources/storage_and_access.tf
@@ -41,6 +41,15 @@ resource "aws_s3_bucket" "govuk-mongodb-backup-s3" {
     versioning {
         enabled = "${var.versioning}"
     }
+
+    lifecycle_rule {
+        prefix = ""
+        enabled = true
+
+        noncurrent_version_expiration {
+            days = 7
+        }
+    }
 }
 
 
@@ -55,6 +64,23 @@ resource "aws_s3_bucket" "govuk-mongodb-backup-s3-daily" {
 
     versioning {
         enabled = "${var.versioning}"
+    }
+
+    lifecycle_rule {
+        prefix = ""
+        enabled = true
+
+        noncurrent_version_transition {
+            days = 30
+            storage_class = "STANDARD_IA"
+        }
+        noncurrent_version_transition {
+            days = 60
+            storage_class = "GLACIER"
+        }
+        noncurrent_version_expiration {
+            days = 90
+        }
     }
 }
 

--- a/projects/mysql_xtrabackups/resources/storage_and_access.tf
+++ b/projects/mysql_xtrabackups/resources/storage_and_access.tf
@@ -5,4 +5,5 @@ module "private_s3_bucket" {
     environment = "${var.environment}"
     team        = "Infrastructure"
     username    = "govuk-mysql-xtrabackups"
+    lifecycle   = "true"
 }

--- a/projects/wal-e_backups_api-postgresql/resources/storage_and_access.tf
+++ b/projects/wal-e_backups_api-postgresql/resources/storage_and_access.tf
@@ -5,4 +5,5 @@ module "private_s3_bucket" {
     environment = "${var.environment}"
     team        = "Infrastructure"
     username    = "govuk-wal-e-backups-api-postgresql"
+    lifecycle   = "true"
 }

--- a/projects/wal-e_backups_postgresql/resources/storage_and_access.tf
+++ b/projects/wal-e_backups_postgresql/resources/storage_and_access.tf
@@ -5,4 +5,5 @@ module "private_s3_bucket" {
     environment = "${var.environment}"
     team        = "Infrastructure"
     username    = "govuk-wal-e-backups-postgresql"
+    lifecycle   = "true"
 }

--- a/projects/wal-e_backups_transition-postgresql/resources/storage_and_access.tf
+++ b/projects/wal-e_backups_transition-postgresql/resources/storage_and_access.tf
@@ -5,4 +5,5 @@ module "private_s3_bucket" {
     environment = "${var.environment}"
     team        = "Infrastructure"
     username    = "govuk-wal-e-backups-transition-postgresql"
+    lifecycle   = "true"
 }


### PR DESCRIPTION
We should enable and deploy lifecycles in S3 buckets that we use for backups so that we don't keep backups forever and waste lots of money. 

This adds the feature. Further details in commits. 

/cc @rjw1 for lifecycle lengths in https://github.com/alphagov/govuk-terraform-provisioning/commit/ac105ab0a5ae38fbf69167e072f8970a4a61c3e8