### PR TITLE
MongoDB bucket Lifecycles

### DIFF
--- a/modules/private_s3_bucket/README.md
+++ b/modules/private_s3_bucket/README.md
@@ -6,3 +6,23 @@ This creates an S3 bucket which has a read-write user and no public access.
 
 If you're creating a bucket which will hold any sensitive data it is recommended
 to use this module.
+
+
+### Permanently deleting objects in s3:
+
+To permanently delete an object you must first set the object to expire with the `expiration` argument within a lifecycle rule.
+```
+expiration {
+  days = 3
+}
+```
+Once the object has expired, it disappears from the bucket but still exists as a `noncurrent` version with a delete marker.
+Please note costs still apply for `noncurrent` objects.
+
+To permanently remove the expired object, you'll need to use the `noncurrent_version_expiration` argument.
+```
+noncurrent_version_expiration {
+  days = 1
+}
+```
+The statement above will permanently delete an s3 object after 1 day of being expired.

--- a/modules/private_s3_bucket/main.tf
+++ b/modules/private_s3_bucket/main.tf
@@ -52,15 +52,15 @@ resource "aws_s3_bucket" "bucket" {
         prefix = ""
         enabled = "${var.lifecycle}"
 
-        noncurrent_version_transition {
+        transition {
             days = 30
             storage_class = "STANDARD_IA"
         }
-        noncurrent_version_transition {
+        transition {
             days = 60
             storage_class = "GLACIER"
         }
-        noncurrent_version_expiration {
+        expiration {
             days = 90
         }
     }

--- a/projects/mongodb-backup-s3/resources/storage_and_access.tf
+++ b/projects/mongodb-backup-s3/resources/storage_and_access.tf
@@ -46,6 +46,10 @@ resource "aws_s3_bucket" "govuk-mongodb-backup-s3" {
         prefix = ""
         enabled = true
 
+        expiration {
+            days = 7
+        }
+
         noncurrent_version_expiration {
             days = 7
         }
@@ -70,16 +74,16 @@ resource "aws_s3_bucket" "govuk-mongodb-backup-s3-daily" {
         prefix = ""
         enabled = true
 
-        noncurrent_version_transition {
+        transition {
             days = 30
             storage_class = "STANDARD_IA"
         }
-        noncurrent_version_transition {
+        transition {
             days = 60
             storage_class = "GLACIER"
         }
-        noncurrent_version_expiration {
-            days = 90
+        expiration {
+            days = 365
         }
     }
 }


### PR DESCRIPTION
While verifying backups we noticed that the lifecycle policy was not removing what we thought were expired files.
We had used the argument noncurrent to specify the files we wanted to apply the lifecycle policy to.
This is incorrect because each backup has a unique name due to the timestamp, therefore making each file current.

Removing the noncurrent prefix will enable the lifecycle policy to target the right files.

Applies to bucket "govuk-mongodb-backup-s3"
Set expiration to 7 days on objects within this bucket.  After 7 days the object changes state from 'current_version' to 'previous_version'.
Once object is in 'previous_version' state.  We apply 'noncurrent' version policy which will permanently delete object after 7 days.

Applies to bucket "govuk-mongodb-backup-s3-daily"
Modified expiration policy to expire backups after 1 year.