### PR TITLE
Add lifecycle rule to Whitehall backups

### DIFF
--- a/projects/whitehall_mysql_xtrabackups/resources/storage_and_access.tf
+++ b/projects/whitehall_mysql_xtrabackups/resources/storage_and_access.tf
@@ -5,4 +5,5 @@ module "private_s3_bucket" {
     environment = "${var.environment}"
     team        = "Infrastructure"
     username    = "govuk-whitehall-mysql-xtrabackups"
+    lifecycle   = "true"
 }


### PR DESCRIPTION
If or when we backup Whitehall MySQL data to S3 we'd probably want some lifecycle
rules enabled.