### PR TITLE
Elasticsearch Snapshot Buckets

### DIFF
--- a/projects/elasticsearch_s3_snapshots/README.md
+++ b/projects/elasticsearch_s3_snapshots/README.md
@@ -1,0 +1,4 @@
+# Elasticsearch Backups
+
+This project creates the resources required to store Elasticsearch snapshots
+in S3.

--- a/projects/elasticsearch_s3_snapshots/resources/storage_and_access.tf
+++ b/projects/elasticsearch_s3_snapshots/resources/storage_and_access.tf
@@ -1,0 +1,99 @@
+variable "bucket_name" {
+  type = "string"
+  default = "govuk-elasticsearch"
+}
+
+variable "team" {
+  type = "string"
+  default = "Infrastructure"
+}
+
+variable "username" {
+  type = "string"
+  default = "govuk-elasticsearch"
+}
+
+variable "versioning" {
+  type = "string"
+  default = "true"
+}
+
+
+resource "template_file" "readwrite_policy_file" {
+  template = "${file("projects/elasticsearch_s3_snapshots/resources/templates/readwrite_policy.tpl")}"
+
+  vars {
+    bucket_name = "${var.bucket_name}"
+    environment = "${var.environment}"
+  }
+}
+
+resource "aws_s3_bucket" "govuk-elasticsearch" {
+  bucket = "${var.bucket_name}-${var.environment}"
+
+  tags {
+    Environment = "${var.environment}"
+    Team = "${var.team}"
+  }
+
+  versioning {
+    enabled = "${var.versioning}"
+  }
+
+  lifecycle_rule {
+    prefix = ""
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+
+    noncurrent_version_expiration {
+      days = 60
+    }
+
+  }
+}
+
+resource "aws_s3_bucket" "govuk-elasticsearch-logs" {
+  bucket = "${var.bucket_name}-logs-${var.environment}"
+
+  tags {
+    Environment = "${var.environment}"
+    Team = "${var.team}"
+  }
+
+  versioning {
+    enabled = "${var.versioning}"
+  }
+
+  lifecycle_rule {
+    prefix = ""
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+
+    noncurrent_version_expiration {
+      days = 60
+    }
+
+  }
+}
+
+resource "aws_iam_policy" "readwrite_policy" {
+  name = "${var.bucket_name}_${var.username}-policy"
+  description = "${var.bucket_name} allow writes"
+  policy = "${template_file.readwrite_policy_file.rendered}"
+}
+
+resource "aws_iam_user" "iam_user" {
+  name = "${var.username}"
+}
+
+resource "aws_iam_policy_attachment" "iam_policy_attachment" {
+  name = "${var.bucket_name}_${var.username}_attachment_policy"
+  users = ["${aws_iam_user.iam_user.name}"]
+  policy_arn = "${aws_iam_policy.readwrite_policy.arn}"
+}

--- a/projects/elasticsearch_s3_snapshots/resources/templates/readwrite_policy.tpl
+++ b/projects/elasticsearch_s3_snapshots/resources/templates/readwrite_policy.tpl
@@ -1,0 +1,34 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListBucketVersions"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}-${environment}",
+        "arn:aws:s3:::${bucket_name}-logs-${environment}"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetObject",
+        "s3:GetObjectACL",
+        "s3:PutObject",
+        "s3:PutObjectACL",
+        "S3:DeleteObject",
+        "s3:AbortMultipartUpload",
+        "s3:ListMultipartUploadParts"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}-${environment}/*",
+        "arn:aws:s3:::${bucket_name}-logs-${environment}/*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
What
Part of the disaster recovery work. Relates to https://github.com/alphagov/govuk-puppet/pull/4637
The s3 resources needed for backing up snapshots have not yet been provisioned.

How
Create an S3 elasticsearch project to provision buckets, accounts and lifecyle rules for both elasticsearch clusters.
- Snapshots will expire after 6 months and be deleted 1 month after that