### PR TITLE
Elasticsearch Snapshot Buckets 2

### DIFF
--- a/projects/elasticsearch_s3_snapshots/resources/storage_and_access.tf
+++ b/projects/elasticsearch_s3_snapshots/resources/storage_and_access.tf
@@ -1,6 +1,6 @@
 variable "bucket_name" {
   type = "string"
-  default = "govuk-elasticsearch"
+  default = "govuk"
 }
 
 variable "team" {
@@ -28,8 +28,8 @@ resource "template_file" "readwrite_policy_file" {
   }
 }
 
-resource "aws_s3_bucket" "govuk-elasticsearch" {
-  bucket = "${var.bucket_name}-${var.environment}"
+resource "aws_s3_bucket" "govuk-api-elasticsearch" {
+  bucket = "${var.bucket_name}-api-elasticsearch-${var.environment}"
 
   tags {
     Environment = "${var.environment}"
@@ -55,8 +55,8 @@ resource "aws_s3_bucket" "govuk-elasticsearch" {
   }
 }
 
-resource "aws_s3_bucket" "govuk-elasticsearch-logs" {
-  bucket = "${var.bucket_name}-logs-${var.environment}"
+resource "aws_s3_bucket" "govuk-logs-elasticsearch" {
+  bucket = "${var.bucket_name}-logs-elasticsearch-${var.environment}"
 
   tags {
     Environment = "${var.environment}"

--- a/projects/elasticsearch_s3_snapshots/resources/templates/readwrite_policy.tpl
+++ b/projects/elasticsearch_s3_snapshots/resources/templates/readwrite_policy.tpl
@@ -10,8 +10,8 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::${bucket_name}-${environment}",
-        "arn:aws:s3:::${bucket_name}-logs-${environment}"
+        "arn:aws:s3:::${bucket_name}-api-elasticserach-${environment}",
+        "arn:aws:s3:::${bucket_name}-logs-elasticsearch-${environment}"
       ]
     },
     {
@@ -26,8 +26,8 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::${bucket_name}-${environment}/*",
-        "arn:aws:s3:::${bucket_name}-logs-${environment}/*"
+        "arn:aws:s3:::${bucket_name}-api-elasticserach-${environment}/*",
+        "arn:aws:s3:::${bucket_name}-logs-elasticsearch-${environment}/*"
       ]
     }
   ]


### PR DESCRIPTION
Renaming resources to reflect changes made in this PR: https://github.com/alphagov/govuk-puppet/pull/4917

Bucket name format is govuk-<cluster class>-<environment>
i.e. govuk-logs-elastcsearch-integration

The logic and policies remain the same.