### PR TITLE
Add bucket to host developer documentation

### DIFF
--- a/projects/developer_docs/resources/automated-user-iam.tf
+++ b/projects/developer_docs/resources/automated-user-iam.tf
@@ -1,0 +1,25 @@
+resource "aws_iam_user" "developer-docs-user" {
+    name = "${var.bucket_name}_user"
+}
+
+data "template_file" "developer_docs_automated_read_write" {
+    template = "${file("projects/developer_docs/resources/templates/read_write_user.tpl")}"
+
+    vars {
+        bucket_name = "${var.bucket_name}"
+        environment = "${var.environment}"
+        owner = "Finding Things"
+    }
+}
+
+resource "aws_iam_policy" "developer_docs_automated_read_write" {
+    name = "${var.bucket_name}_user_policy"
+    description = "${var.bucket_name} allows read/write"
+    policy = "${data.template_file.developer_docs_automated_read_write.rendered}"
+}
+
+resource "aws_iam_policy_attachment" "developer_docs_attachment" {
+    name = "${var.bucket_name}_user_attachment_policy"
+    users = ["${aws_iam_user.developer-docs-user.name}"]
+    policy_arn = "${aws_iam_policy.developer_docs_automated_read_write.arn}"
+}

--- a/projects/developer_docs/resources/buckets.tf
+++ b/projects/developer_docs/resources/buckets.tf
@@ -1,0 +1,9 @@
+resource "aws_s3_bucket" "developer_docs" {
+    bucket = "${var.bucket_name}-${var.environment}"
+    acl = "public-read"
+
+    website {
+        index_document = "index.html"
+        error_document = "error.html"
+    }
+}

--- a/projects/developer_docs/resources/templates/read_write_user.tpl
+++ b/projects/developer_docs/resources/templates/read_write_user.tpl
@@ -1,0 +1,42 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListAllMyBuckets"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::*"
+      ]
+    },
+    {
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListBucketVersions"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}-${environment}"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetObject",
+        "s3:GetObjectACL",
+        "s3:PutObject",
+        "s3:PutObjectACL",
+        "S3:DeleteObject",
+        "s3:AbortMultipartUpload",
+        "s3:ListMultipartUploadParts"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}-${environment}/*"
+      ]
+    }
+  ]
+}

--- a/projects/developer_docs/resources/variables.tf
+++ b/projects/developer_docs/resources/variables.tf
@@ -1,0 +1,4 @@
+variable "bucket_name" {
+    type    = "string"
+    default = "govuk-developer-documentation"
+}


### PR DESCRIPTION
This commit adds terraform instructions to create a bucket for the developer documentation on GOV.UK. It will be served from docs.publishing.service.gov.uk (either via a reverse proxy or via cloudfront, we aren't sure what's possible yet).

The bucket has one user, which can read & write. It will probably be used to set up automatic deployment from jenkins.

The bucket is exposed as a website, which means that after uploading the files it should be publicly accessible from:

https://govuk-developer-documentation-integration.s3.amazonaws.com/
https://govuk-developer-documentation-staging.s3.amazonaws.com/
https://govuk-developer-documentation-production.s3.amazonaws.com/

http://govuk-developer-documentation-integration.s3-website-eu-west-1.amazonaws.com/
http://govuk-developer-documentation-staging.s3-website-eu-west-1.amazonaws.com/
http://govuk-developer-documentation-production.s3-website-eu-west-1.amazonaws.com/

Trello: https://trello.com/c/sOqubT5e