### PR TITLE
GOVUK offsite backckups

### DIFF
--- a/projects/datastore-offsite-backups/resources/production/buckets_and_access.tf
+++ b/projects/datastore-offsite-backups/resources/production/buckets_and_access.tf
@@ -1,0 +1,50 @@
+resource "aws_s3_bucket" "govuk-offsite-backups" {
+  bucket = "${var.bucket_name}-${var.environment}"
+
+  tags {
+    Environment = "${var.environment}"
+    Team = "${var.team}"
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    prefix = ""
+    enabled = true
+
+    expiration {
+      days = 1
+    }
+
+    noncurrent_version_transition {
+      days = 30
+      storage_class = "STANDARD_IA"
+    }
+  }
+}
+
+data "template_file" "read_write_user" {
+  template = "${file("projects/datastore-offsite-backups/resources/templates/read_write_user.tpl")}"
+
+  vars {
+    bucket_name = "${var.bucket_name}"
+    environment = "${var.environment}"
+  }
+}
+
+resource "aws_iam_policy" "read_write_user" {
+  name = "${var.bucket_name}"
+  policy = "${data.template_file.read_write_user.rendered}"
+}
+
+resource "aws_iam_policy_attachment" "govuk-offsite-backups" {
+  name = "${var.bucket_name}_govuk_offsite_backups_attachment_polocy"
+  users = ["${aws_iam_user.iam_user.name}"]
+  policy_arn = "${aws_iam_policy.read_write_user.arn}"
+}
+
+resource "aws_iam_user" "iam_user" {
+  name = "${var.username}"
+}

--- a/projects/datastore-offsite-backups/resources/templates/read_write_user.tpl
+++ b/projects/datastore-offsite-backups/resources/templates/read_write_user.tpl
@@ -1,0 +1,42 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListAllMyBuckets"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::*"
+      ]
+    },
+    {
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListBucketVersions"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}-${environment}"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetObject",
+        "s3:GetObjectACL",
+        "s3:PutObject",
+        "s3:PutObjectACL",
+        "S3:DeleteObject",
+        "s3:AbortMultipartUpload",
+        "s3:ListMultipartUploadParts"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}-${environment}/*"
+      ]
+    }
+  ]
+}

--- a/projects/datastore-offsite-backups/resources/variables.tf
+++ b/projects/datastore-offsite-backups/resources/variables.tf
@@ -1,0 +1,14 @@
+variable "bucket_name" {
+  type    = "string"
+  default = "govuk-offsite-backups"
+}
+
+variable "team" {
+  type = "string"
+  default = "Infrastructure"
+}
+
+variable "username" {
+  type = "string"
+  default = "govuk-offsite-backups"
+}


### PR DESCRIPTION
An s3 bucket which serves as the endpoint for datastore backups.

The lifecycle rules have not been officially defined but as they are?  

* Versioning is enabled 
* Versions stay current for one day (because backups are taken daily) 
* After 30 days of being non_current versions.  Backups are transitioned to the **_STANDARD_IA_** storage class (_saves Money_).
* **No data is deleted**

User, govuk-offsite-backup's keys will be generated by hand from the console.

See https://trello.com/c/y3JIRupU