### PR TITLE
Add infrastructure team

### DIFF
--- a/modules/admins/main.tf
+++ b/modules/admins/main.tf
@@ -23,10 +23,6 @@ resource "aws_iam_user" "mikaelallison_user" {
     name = "mikaelallison"
 }
 
-resource "aws_iam_user" "samcook_user" {
-    name = "samcook"
-}
-
 
 resource "aws_iam_group_membership" "infrastructure_membership" {
     name = "infrastructure-group-membership"
@@ -36,7 +32,6 @@ resource "aws_iam_group_membership" "infrastructure_membership" {
         "${aws_iam_user.deanwilson_user.name}",
         "${aws_iam_user.lauramartin_user.name}",
         "${aws_iam_user.mikaelallison_user.name}",
-        "${aws_iam_user.samcook_user.name}",
     ]
     group = "${aws_iam_group.infrastructure_group.name}"
 }

--- a/projects/user_management/resources/groups.tf
+++ b/projects/user_management/resources/groups.tf
@@ -13,6 +13,11 @@ resource "aws_iam_group" "publishing_platform" {
     path = "/groups/"
 }
 
+resource "aws_iam_group" "infrastructure_team" {
+    name = "infrastructure_team"
+    path = "/groups/"
+}
+
 resource "aws_iam_policy_attachment" "base-user-console-access_user_attachment" {
     name = "base-user-console-access_user_attachment_policy"
     groups = [
@@ -20,6 +25,29 @@ resource "aws_iam_policy_attachment" "base-user-console-access_user_attachment" 
       "${aws_iam_group.publishing_platform.name}"
     ]
     policy_arn = "${aws_iam_policy.base-user-console-access.arn}"
+}
+
+resource "aws_iam_policy" "infrastructure_team_policy" {
+    name = "infrastructure_team_policy"
+    description = "Admin policy: full access"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "infrastructure_team_attachment" {
+    name = "infrastructure_team_policy_attachment"
+    groups = ["${aws_iam_group.infrastructure_team.name}"]
+    policy_arn = "${aws_iam_policy.infrastructure_team_policy.arn}"
 }
 
 

--- a/projects/user_management/resources/integration/infrastructure_team.tf
+++ b/projects/user_management/resources/integration/infrastructure_team.tf
@@ -1,0 +1,7 @@
+resource "aws_iam_group_membership" "infrastructure_team" {
+    name = "infrastructure_team-group-membership"
+    users = [
+        "${aws_iam_user.samcook.name}",
+    ]
+    group = "${aws_iam_group.infrastructure_team.name}"
+}

--- a/projects/user_management/resources/integration/users.tf
+++ b/projects/user_management/resources/integration/users.tf
@@ -33,6 +33,11 @@ resource "aws_iam_user" "kevindew" {
     path = "/users/"
 }
 
+resource "aws_iam_user" "samcook" {
+    name = "samcook"
+    path = "/users/"
+}
+
 resource "aws_iam_user" "simonhughesdon" {
     name = "simonhughesdon"
     path = "/users/"

--- a/projects/user_management/resources/production/infrastructure_team.tf
+++ b/projects/user_management/resources/production/infrastructure_team.tf
@@ -1,0 +1,7 @@
+resource "aws_iam_group_membership" "infrastructure_team" {
+    name = "infrastructure_team-group-membership"
+    users = [
+        "${aws_iam_user.samcook.name}",
+    ]
+    group = "${aws_iam_group.infrastructure_team.name}"
+}

--- a/projects/user_management/resources/production/users.tf
+++ b/projects/user_management/resources/production/users.tf
@@ -33,6 +33,11 @@ resource "aws_iam_user" "kevindew" {
     path = "/users/"
 }
 
+resource "aws_iam_user" "samcook" {
+    name = "samcook"
+    path = "/users/"
+}
+
 resource "aws_iam_user" "simonhughesdon" {
     name = "simonhughesdon"
     path = "/users/"

--- a/projects/user_management/resources/staging/infrastructure_team.tf
+++ b/projects/user_management/resources/staging/infrastructure_team.tf
@@ -1,0 +1,7 @@
+resource "aws_iam_group_membership" "infrastructure_team" {
+    name = "infrastructure_team-group-membership"
+    users = [
+        "${aws_iam_user.samcook.name}",
+    ]
+    group = "${aws_iam_group.infrastructure_team.name}"
+}

--- a/projects/user_management/resources/staging/users.tf
+++ b/projects/user_management/resources/staging/users.tf
@@ -1,0 +1,9 @@
+#
+# New users should be added here.
+#   In alphabetical order.
+#
+
+resource "aws_iam_user" "samcook" {
+    name = "samcook"
+    path = "/users/"
+}


### PR DESCRIPTION
Replace the old `modules/admin/main.tf` method of adding users (which doesn't work) with a new style team in `user_management`.