### PR TITLE
Adjust govuk-backup S3 permissions

### DIFF
--- a/projects/datastore-offsite-backups/resources/templates/read_write_user.tpl
+++ b/projects/datastore-offsite-backups/resources/templates/read_write_user.tpl
@@ -25,13 +25,7 @@
     },
     {
       "Action": [
-        "s3:GetObject",
-        "s3:GetObjectACL",
-        "s3:PutObject",
-        "s3:PutObjectACL",
-        "S3:DeleteObject",
-        "s3:AbortMultipartUpload",
-        "s3:ListMultipartUploadParts"
+        "s3:*"
       ],
       "Effect": "Allow",
       "Resource": [


### PR DESCRIPTION
The initial backup worked, but in trying to run future backups duplicity threw a 403 when trying to connect to the S3 bucket. I believe it may have been trying to move or do something with the files in the bucket.

It's easiest to just allow full permission by that user. It only has access to that bucket.

Note: I have devops'ed this change to get backups working, but this will need to be deployed to ensure the terraform state file doesn't get out of sync.