### PR TITLE
Add S3 bucket for mirroring

### DIFF
--- a/projects/s3-mirrors/README.md
+++ b/projects/s3-mirrors/README.md
@@ -1,0 +1,6 @@
+# S3 Mirrors
+
+## Introduction
+
+This adds an S3 bucket that can be used for mirroring static content to AWS.
+The bucket will be accessed from fastly in case of fail-over.

--- a/projects/s3-mirrors/resources/buckets.tf
+++ b/projects/s3-mirrors/resources/buckets.tf
@@ -1,0 +1,12 @@
+resource "aws_s3_bucket" "govuk_mirror" {
+  bucket = "govuk-mirror-${var.environment}"
+
+  tags {
+    Environment = "${var.environment}"
+    Team = "Infrastructure"
+  }
+
+  versioning {
+    enabled = true
+  }
+}

--- a/projects/s3-mirrors/resources/mirror-access-policy.tf
+++ b/projects/s3-mirrors/resources/mirror-access-policy.tf
@@ -1,0 +1,37 @@
+data "aws_iam_policy_document" "s3_mirror_writer_policy_doc" {
+  Statement {
+    Sid = "S3SyncReadLists"
+    Action = [
+      "s3:GetBucketLocation",
+      "s3:ListAllMyBuckets",
+    ]
+    Resource = "arn:aws:s3:::*"
+  }
+
+  Statement {
+    Sid = "S3SyncReadWriteBucket"
+    Action = ["s3:*"]
+    Resource =  "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}"
+    principal {
+      type = "AWS"
+      identifiers = [
+        "${aws_iam_role.s3_sync_user_role}"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_policy" "s3_mirror_writer_policy" {
+  name = "s3_mirror_writer_policy_for_${aws_s3_bucket.govuk_mirror.name}"
+  policy = "${data.aws_iam_policy_document.s3_mirror_writer_policy_doc.json}"
+}
+
+resource "aws_iam_user" "s3_mirror_writer_user" {
+  name = "s3_mirror_writer"
+}
+
+resource "aws_iam_policy_attachment" "s3_mirror_writer_user_policy" {
+  name = "s3_mirror_writer_user_policy_attachement"
+  users = ["${aws_iam_user.s3_mirror_writer_user.name}"]
+  policy_arn = "${aws_iam_policy.s3_mirror_writer_policy.arn}"
+}


### PR DESCRIPTION
This adds necessary terraform to construct both a S3 bucket and
the appropriate user to write to it for mirroring.