### PR TITLE
Add a bucket for storing DNS tfstate files

### DIFF
--- a/projects/dns-tfstate-store/README.md
+++ b/projects/dns-tfstate-store/README.md
@@ -1,0 +1,5 @@
+# DNS tfstate store
+
+## Introduction
+
+This will store the state of the terraform used to deploy DNS records to our providers.

--- a/projects/dns-tfstate-store/resources/buckets.tf
+++ b/projects/dns-tfstate-store/resources/buckets.tf
@@ -1,0 +1,13 @@
+resource "aws_s3_bucket" "dns_state_bucket" {
+  bucket = "dns-state-bucket-${var.environment}"
+  acl = "private"
+
+  tags {
+    Environment = "${var.environment}"
+    Team = "Infrastructure"
+  }
+
+  versioning {
+    enabled = true
+  }
+}


### PR DESCRIPTION
We need to store the DNS terraform state in a remote location. This
adds an S3 bucket that can be used for this.