### PR TITLE
Fix bugs in initial terraform resources

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ task :validate_environment do
   end
 
   unless ENV.include?('TF_VAR_account_id')
-    warn 'Please set the "TF_VAR_account_id" environment variable.'
+    warn 'Please set the "TF_VAR_account_id" environment variable to the name of the aws account i.e. "govuk-infrastructure-integration".'
     exit 1
   end
 

--- a/projects/s3-mirrors/resources/mirror-access-policy.tf
+++ b/projects/s3-mirrors/resources/mirror-access-policy.tf
@@ -1,28 +1,26 @@
 data "aws_iam_policy_document" "s3_mirror_writer_policy_doc" {
-  Statement {
-    Sid = "S3SyncReadLists"
-    Action = [
+  statement {
+    sid = "S3SyncReadLists"
+    actions = [
       "s3:GetBucketLocation",
       "s3:ListAllMyBuckets",
     ]
-    Resource = "arn:aws:s3:::*"
+    resources = [
+      "arn:aws:s3:::*",
+    ]
   }
 
-  Statement {
-    Sid = "S3SyncReadWriteBucket"
-    Action = ["s3:*"]
-    Resource =  "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}"
-    principal {
-      type = "AWS"
-      identifiers = [
-        "${aws_iam_role.s3_sync_user_role}"
-      ]
-    }
+  statement {
+    sid = "S3SyncReadWriteBucket"
+    actions = ["s3:*"]
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}",
+    ]
   }
 }
 
 resource "aws_iam_policy" "s3_mirror_writer_policy" {
-  name = "s3_mirror_writer_policy_for_${aws_s3_bucket.govuk_mirror.name}"
+  name = "s3_mirror_writer_policy_for_${aws_s3_bucket.govuk_mirror.id}"
   policy = "${data.aws_iam_policy_document.s3_mirror_writer_policy_doc.json}"
 }
 


### PR DESCRIPTION
This fixes several errors found whilst deploying terraform to
integration that were not picked up by e.g. `terraform plan`.

This will now create an S3 bucket, user and appropriate policy in AWS
for use creating site mirrors.