### PR TITLE
Add policy to allow Fastly access to the S3 mirror bucket

### DIFF
--- a/projects/s3-mirrors/resources/buckets.tf
+++ b/projects/s3-mirrors/resources/buckets.tf
@@ -10,3 +10,8 @@ resource "aws_s3_bucket" "govuk_mirror" {
     enabled = true
   }
 }
+
+resource "aws_s3_bucket_policy" "govuk_mirror_fastly_policy" {
+    bucket = "${aws_s3_bucket.govuk_mirror.id}"
+    policy = "${data.aws_iam_policy_document.s3_mirror_fastly_read_policy_doc.json}"
+}

--- a/projects/s3-mirrors/resources/mirror-crawler-write-policy.tf
+++ b/projects/s3-mirrors/resources/mirror-crawler-write-policy.tf
@@ -1,4 +1,4 @@
-data "aws_iam_policy_document" "s3_mirror_writer_policy_doc" {
+data "aws_iam_policy_document" "s3_mirror_crawler_writer_policy_doc" {
   statement {
     sid = "S3SyncReadLists"
     actions = [
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "s3_mirror_writer_policy_doc" {
 
 resource "aws_iam_policy" "s3_mirror_writer_policy" {
   name = "s3_mirror_writer_policy_for_${aws_s3_bucket.govuk_mirror.id}"
-  policy = "${data.aws_iam_policy_document.s3_mirror_writer_policy_doc.json}"
+  policy = "${data.aws_iam_policy_document.s3_mirror_crawler_writer_policy_doc.json}"
 }
 
 resource "aws_iam_user" "s3_mirror_writer_user" {

--- a/projects/s3-mirrors/resources/mirror-fastly-read-policy.tf
+++ b/projects/s3-mirrors/resources/mirror-fastly-read-policy.tf
@@ -1,0 +1,19 @@
+provider "fastly" {
+  # We only want to use fastly's data API
+  api_key = "test"
+}
+
+data "fastly_ip_ranges" "fastly" {}
+
+data "aws_iam_policy_document" "s3_mirror_fastly_read_policy_doc" {
+  statement {
+    sid = "S3FastlyReadBucket"
+    actions = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}"]
+    condition {
+      test = "IpAddress"
+      variable = "aws:SourceIp"
+      values = ["${data.fastly_ip_ranges.fastly.cidr_blocks}"]
+    }
+  }
+}


### PR DESCRIPTION
We want to use S3 as a failover mirror. This means fastly needs to be
able to access the contents of the mirror bucket. This adds an IP
based access policy to the bucket that allows fastly to read it.