### PR TITLE
Fix s3 mirror policy

### DIFF
--- a/projects/s3-mirrors/resources/mirror-crawler-write-policy.tf
+++ b/projects/s3-mirrors/resources/mirror-crawler-write-policy.tf
@@ -15,6 +15,7 @@ data "aws_iam_policy_document" "s3_mirror_crawler_writer_policy_doc" {
     actions = ["s3:*"]
     resources = [
       "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}/*",
     ]
   }
 }

--- a/projects/s3-mirrors/resources/mirror-fastly-read-policy.tf
+++ b/projects/s3-mirrors/resources/mirror-fastly-read-policy.tf
@@ -9,7 +9,10 @@ data "aws_iam_policy_document" "s3_mirror_fastly_read_policy_doc" {
   statement {
     sid = "S3FastlyReadBucket"
     actions = ["s3:GetObject"]
-    resources = ["arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}"]
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}/*",
+    ]
     condition {
       test = "IpAddress"
       variable = "aws:SourceIp"

--- a/projects/s3-mirrors/resources/mirror-fastly-read-policy.tf
+++ b/projects/s3-mirrors/resources/mirror-fastly-read-policy.tf
@@ -15,5 +15,11 @@ data "aws_iam_policy_document" "s3_mirror_fastly_read_policy_doc" {
       variable = "aws:SourceIp"
       values = ["${data.fastly_ip_ranges.fastly.cidr_blocks}"]
     }
+
+    # Apparently bucket policies must have a principal
+    principals {
+      type = "AWS"
+      identifiers = ["*"]
+    }
   }
 }


### PR DESCRIPTION
The crawler writer did not have full write access to the govuk mirror buckets. This corrects that problem by granting it full permissions on both the bucket and the contents of the bucket.

This also fixes a bug found in the process of testing this where the fastly read policy was missing a principal.