### PR TITLE
Remove the unused account_id variable

### DIFF
--- a/configs/common_variables.tf
+++ b/configs/common_variables.tf
@@ -3,10 +3,6 @@ variable "environment" {
   type = "string"
 }
 
-variable "account_id" {
-  description = "AWS Account ID"
-}
-
 # FIXME: this will be extracted when we have multiple providers, possibly to
 # configs/<provider_name>.tf
 variable "aws_default_region" {


### PR DESCRIPTION
The `account_id` variable defined in `config/common_variables` is not used in any current projects. The only usage is in `old-projects/packer_ami_builder` which is deprecated.

Where the `account_id` of the current user is needed the data resource `aws_caller_identity`'s attribute `current.account_id` should be preferred.