### PR TITLE
Remove lifecycle and versioning

### DIFF
--- a/projects/datastore-offsite-backups/resources/buckets_and_access.tf
+++ b/projects/datastore-offsite-backups/resources/buckets_and_access.tf
@@ -6,23 +6,6 @@ resource "aws_s3_bucket" "govuk-offsite-backups" {
     Team = "${var.team}"
   }
 
-  versioning {
-    enabled = true
-  }
-
-  lifecycle_rule {
-    prefix = ""
-    enabled = true
-
-    expiration {
-      days = 1
-    }
-
-    noncurrent_version_transition {
-      days = 30
-      storage_class = "STANDARD_IA"
-    }
-  }
 }
 
 data "template_file" "read_write_user" {


### PR DESCRIPTION
Duplicity has lots of strange errors related to orphaned files and seems to run a full backup each time it runs, and doesn't leave any old backups.

I think this may be related to the lifecycle rule of a single day. Duplicity itself should deal with the clean up, and I feel that having both versioning and lifecycles enabled on the bucket complicate matters unnecessarily.

Deployment will require emptying the bucket, destroying it and redeploying it.