### PR TITLE
Enable logging on S3 mirror buckets

### DIFF
--- a/projects/s3-mirrors/resources/buckets.tf
+++ b/projects/s3-mirrors/resources/buckets.tf
@@ -1,3 +1,8 @@
+resource "aws_s3_bucket" "govuk_mirror_access_logs" {
+  bucket = "govuk-mirror-${var.environment}-access-logs"
+  acl    = "log-delivery-write"
+}
+
 resource "aws_s3_bucket" "govuk_mirror" {
   bucket = "govuk-mirror-${var.environment}"
 
@@ -8,6 +13,11 @@ resource "aws_s3_bucket" "govuk_mirror" {
 
   versioning {
     enabled = true
+  }
+
+  logging {
+    target_bucket = "${aws_s3_bucket.govuk_mirror_access_logs.id}"
+    target_prefix = "log/"
   }
 }
 


### PR DESCRIPTION
Enable the logging option on the S3 mirror bucket, and create a
different bucket to store the access logs.