### PR TITLE
Add user, group and policy for govuk-ci user on Integration

### DIFF
--- a/projects/user_management/resources/groups.tf
+++ b/projects/user_management/resources/groups.tf
@@ -23,6 +23,11 @@ resource "aws_iam_group" "infrastructure_team" {
     path = "/groups/"
 }
 
+resource "aws_iam_group" "ci" {
+    name = "ci"
+    path = "/groups/"
+}
+
 resource "aws_iam_policy_attachment" "base-user-console-access_user_attachment" {
     name = "base-user-console-access_user_attachment_policy"
     groups = [
@@ -76,3 +81,35 @@ resource "aws_iam_policy" "base-user-console-access" {
     description = "base-user-console-access allows standard user tasks like create access key"
     policy = "${data.template_file.base-user-console-access.rendered}"
 }
+
+resource "aws_iam_policy" "ci_policy" {
+    name = "ci_policy"
+    description = "CI policy: lunch instances"
+    policy = <<EOF
+{
+   "Version": "2012-10-17",
+   "Statement": [{
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances", "ec2:DescribeImages",
+        "ec2:DescribeKeyPairs","ec2:DescribeVpcs", "ec2:DescribeSubnets", 
+        "ec2:DescribeSecurityGroups"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": "*"
+    }
+   ]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "ci_attachment" {
+    name = "ci_policy_attachment"
+    groups = ["${aws_iam_group.ci.name}"]
+    policy_arn = "${aws_iam_policy.ci_policy.arn}"
+}
+

--- a/projects/user_management/resources/integration/ci.tf
+++ b/projects/user_management/resources/integration/ci.tf
@@ -1,0 +1,8 @@
+
+resource "aws_iam_group_membership" "ci" {
+    name = "ci-group-membership"
+    users = [ 
+        "${aws_iam_user.govuk-ci.name}",
+    ]
+    group = "${aws_iam_group.ci.name}"
+}

--- a/projects/user_management/resources/integration/users.tf
+++ b/projects/user_management/resources/integration/users.tf
@@ -23,6 +23,11 @@ resource "aws_iam_user" "deborahchua" {
     path = "/users/"
 }
 
+resource "aws_iam_user" "govuk-ci" {
+    name = "govuk-ci"
+    path = "/users/"
+}
+
 resource "aws_iam_user" "grahampengelly" {
     name = "grahampengelly"
     path = "/users/"


### PR DESCRIPTION
As part of our new Training environment, we want Jenkins to be able
to launch EC2 instances automatically on the Integration account. This
change adds a policy, group and user that we can use from Jenkins
to do this job

Link to EC2 policy example: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-policies-ec2-console.html#ex-launch-wizard