### PR TITLE
Add S3 mirror policy for Pingdom IPs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -197,7 +197,7 @@ def _flatten_project
     next if Dir["#{dir}/*.tf"].empty?
 
     puts "Working on #{Dir[dir + '/*.tf']}" if debug
-    FileUtils.cp( Dir["#{dir}/*.tf"], tmp_dir)
+    FileUtils.cp( Dir["#{dir}/*"], tmp_dir)
   end
 
   _run_system_command("terraform get #{tmp_dir}")

--- a/projects/s3-mirrors/resources/buckets.tf
+++ b/projects/s3-mirrors/resources/buckets.tf
@@ -25,3 +25,8 @@ resource "aws_s3_bucket_policy" "govuk_mirror_fastly_policy" {
     bucket = "${aws_s3_bucket.govuk_mirror.id}"
     policy = "${data.aws_iam_policy_document.s3_mirror_fastly_read_policy_doc.json}"
 }
+
+resource "aws_s3_bucket_policy" "govuk_mirror_pingdom_policy" {
+    bucket = "${aws_s3_bucket.govuk_mirror.id}"
+    policy = "${data.aws_iam_policy_document.s3_mirror_pingdom_read_policy_doc.json}"
+}

--- a/projects/s3-mirrors/resources/mirror-pingdom-read-policy.tf
+++ b/projects/s3-mirrors/resources/mirror-pingdom-read-policy.tf
@@ -1,0 +1,26 @@
+
+data "external" "pingdom" {
+  program = ["/bin/bash", "${path.module}/pingdom_probe_ips.sh"]
+}
+
+data "aws_iam_policy_document" "s3_mirror_pingdom_read_policy_doc" {
+  statement {
+    sid = "S3PingdomReadBucket"
+    actions = ["s3:GetObject"]
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}",
+      "arn:aws:s3:::${aws_s3_bucket.govuk_mirror.id}/*",
+    ]
+    condition {
+      test = "IpAddress"
+      variable = "aws:SourceIp"
+      values = ["${split(",",data.external.pingdom.result.pingdom_probe_ips)}"]
+    }
+
+    # Apparently bucket policies must have a principal
+    principals {
+      type = "AWS"
+      identifiers = ["*"]
+    }
+  }
+}

--- a/projects/s3-mirrors/resources/pingdom_probe_ips.sh
+++ b/projects/s3-mirrors/resources/pingdom_probe_ips.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# This script pulls Pingdom probe IPs from the feed page and prints a sorted
+# list of CIDR blocks to the standard output in JSON format.
+#
+# Pingdom probe IPs information:
+# https://help.pingdom.com/hc/en-us/articles/203682601-Pingdom-probe-servers-IP-addresses
+#
+# The JSON output needs to meet Terraform external data sources requirements
+# and limitations (at the moment Terraform only supports string data types)
+# https://www.terraform.io/docs/providers/external/data_source.html
+# https://github.com/hashicorp/terraform/issues/12256
+
+curl -s https://my.pingdom.com/probes/feed | grep "pingdom:ip" | sed -e 's|</.*||' -e 's|.*>||' | sort -n -t . -k 1,1 -k 2,2 -k 3,3 -k 4,4 | grep -v ":" | awk '
+BEGIN { ORS = ""; print " { \"pingdom_probe_ips\": \""}
+{ if (NR == 1) { print $1"/32" } else { print ","$1"/32" } }
+END { print " \" }" }
+'
+


### PR DESCRIPTION
We want to add Pingdom checks for our S3 mirrors so we need to whitelist
the probe IPs. These IPs are likely to change, but they can be pulled
automatically as explained in
https://help.pingdom.com/hc/en-us/articles/203682601-Pingdom-probe-servers-IP-addresses

To manage these IPs automatically, there is a bash script that populates
a Terraform external data source. It's been kept very simple so we don't
have to install dependencies just for this on the servers. There is a limitation
in Terraform that it can only pull string values from external data sources
https://github.com/hashicorp/terraform/issues/12256
so we need to manipulate the string in the Terraform code.