### PR TITLE
Configure an S3 bucket for Fastly to deposit logs in

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -196,8 +196,8 @@ def _flatten_project
   [ 'configs', base_path, "#{base_path}/#{deploy_env}" ].each do |dir|
     next if Dir["#{dir}/*.tf"].empty?
 
-    puts "Working on #{Dir[dir + '/*.tf']}" if debug
-    FileUtils.cp( Dir["#{dir}/*"], tmp_dir)
+    puts "Working on #{Dir[dir + '/*']}" if debug
+    FileUtils.cp_r( Dir["#{dir}/*"], tmp_dir)
   end
 
   _run_system_command("terraform get #{tmp_dir}")

--- a/projects/analytics_logging/resources/bucket_and_access.tf
+++ b/projects/analytics_logging/resources/bucket_and_access.tf
@@ -1,0 +1,45 @@
+resource "aws_s3_bucket" "govuk-analytics-logs" {
+  bucket = "govuk-analytics-logs-${var.environment}"
+
+  tags {
+    Environment = "${var.environment}"
+    Team = "Performance"
+  }
+}
+
+data "aws_iam_policy_document" "read_write_policy_document" {
+  statement {
+    actions = [
+      "s3:ListBucket"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.govuk-analytics-logs.arn}"
+    ]
+  }
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.govuk-analytics-logs.arn}/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "fastly_policy" {
+  name = "govuk-analytics-logs_fastly_policy"
+  policy = "${data.aws_iam_policy_document.read_write_policy_document.json}"
+}
+
+resource "aws_iam_policy_attachment" "fastly_user_policy_attachment" {
+  name = "govuk-analytics-logs_fastly_policy_attachment"
+  users = ["${aws_iam_user.fastly_user.name}"]
+  policy_arn = "${aws_iam_policy.fastly_policy.arn}"
+}
+
+resource "aws_iam_user" "fastly_user" {
+  name = "govuk-analytics-logs-fastly"
+}


### PR DESCRIPTION
This will receive logs of the assets service for just `/static/a?`.
This will later be extended with additional roles for analysis of the
collected logs.

Also includes a fix for `rake plan`