### PR TITLE
Set ACL for Asset Manager's S3 bucket to "public-read"

### DIFF
--- a/projects/asset-manager/resources/buckets.tf
+++ b/projects/asset-manager/resources/buckets.tf
@@ -1,4 +1,4 @@
 resource "aws_s3_bucket" "asset-manager" {
   bucket = "${var.bucket_name}-${var.environment}"
-  acl = "private"
+  acl = "public-read"
 }


### PR DESCRIPTION
We want to experiment with having Asset Manager redirect asset URLs to objects on S3 - see [this pull request][1] for details. Note that this experimental Asset Manager behaviour is disabled by default, but can be enabled using environment variables or on a per-request basis using a query string parameter -
 see the [Asset Manager documentation][2].

Previously the ACL for the bucket was set to "private", but now that we want to redirect requests and have S3 serve the asset to the end-user, we need to set the ACL to "public-read". This means that as well as the bucket owner getting "FULL_CONTROL", the `AllUsers` group also gets "READ" access. See the [S3 "Canned ACL" documentation][3] for details.

Note that we will want to create a DNS `CNAME` and rename the S3 bucket at some point to get the full effect, but this feels like a useful first step.

[1]: alphagov/asset-manager#112
[2]: https://github.com/alphagov/asset-manager/blob/master/README.md#assets-on-s3
[3]: http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl