### PR TITLE
Remove IAM Access Key for Asset Manager user

### DIFF
--- a/projects/asset-manager/resources/users.tf
+++ b/projects/asset-manager/resources/users.tf
@@ -2,10 +2,6 @@ resource "aws_iam_user" "asset-manager" {
   name = "${var.bucket_name}-${var.environment}-user"
 }
 
-resource "aws_iam_access_key" "asset-manager" {
-  user = "${aws_iam_user.asset-manager.name}"
-}
-
 data "aws_iam_policy_document" "asset-manager" {
   statement {
     sid = "1"


### PR DESCRIPTION
It seems that we shouldn't be creating IAM access keys using Terraform
for the following reasons:

1. This results in the IAM user's access and secret keys being stored in
the .tfstate file

2. The infrastructure team have a separate process for creating/managing
IAM access keys

In order to test this change I manually added a second access key to the
asset manager user in my AWS account. This replicates the access key
that has been manually added by the infrastructure team in production.

I applied the change and observed:

* The original access key was removed from the IAM user
* The manually created access key remained on the IAM user
* The access and secret keys were removed from the .tfstate file