### PR TITLE
Add "public read" policy to Asset Manager S3 bucket

### DIFF
--- a/projects/asset-manager/resources/buckets.tf
+++ b/projects/asset-manager/resources/buckets.tf
@@ -2,24 +2,3 @@ resource "aws_s3_bucket" "asset-manager" {
   bucket = "${var.bucket_name}-${var.environment}"
   acl = "private"
 }
-
-data "aws_iam_policy_document" "asset-manager-bucket" {
-  statement {
-    sid = "PublicReadForGetBucketObjects"
-    principals {
-      type = "AWS"
-      identifiers = ["*"]
-    }
-    actions = [
-      "s3:GetObject"
-    ]
-    resources = [
-      "arn:aws:s3:::${var.bucket_name}-${var.environment}/*"
-    ]
-  }
-}
-
-resource "aws_s3_bucket_policy" "asset-manager" {
-  bucket = "${aws_s3_bucket.asset-manager.id}"
-  policy = "${data.aws_iam_policy_document.asset-manager-bucket.json}"
-}

--- a/projects/asset-manager/resources/buckets.tf
+++ b/projects/asset-manager/resources/buckets.tf
@@ -2,3 +2,24 @@ resource "aws_s3_bucket" "asset-manager" {
   bucket = "${var.bucket_name}-${var.environment}"
   acl = "private"
 }
+
+data "aws_iam_policy_document" "asset-manager-bucket" {
+  statement {
+    sid = "PublicReadForGetBucketObjects"
+    principals {
+      type = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:GetObject"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.bucket_name}-${var.environment}/*"
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "asset-manager" {
+  bucket = "${aws_s3_bucket.asset-manager.id}"
+  policy = "${data.aws_iam_policy_document.asset-manager-bucket.json}"
+}

--- a/projects/asset-manager/resources/integration/bucket-policy.tf
+++ b/projects/asset-manager/resources/integration/bucket-policy.tf
@@ -1,0 +1,20 @@
+data "aws_iam_policy_document" "asset-manager-bucket" {
+  statement {
+    sid = "PublicReadForGetBucketObjects"
+    principals {
+      type = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:GetObject"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.bucket_name}-${var.environment}/*"
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "asset-manager" {
+  bucket = "${aws_s3_bucket.asset-manager.id}"
+  policy = "${data.aws_iam_policy_document.asset-manager-bucket.json}"
+}


### PR DESCRIPTION
We want to experiment with having Asset Manager redirect asset URLs to objects on S3 - see [this pull request][1] for details. Note that this experimental Asset Manager behaviour is disabled by default, but can be enabled [using environment variables or on a per-request basis using a query string parameter][2].

Previously the default bucket policy did not allow public read access, but now that we want to redirect requests and have S3 serve the asset to the end-user, we need to add an explicit policy to the bucket to allow public read access.

We considered setting the policy on individual objects, but decided it would be simpler to apply it to the bucket as a whole and then create a separate bucket if we need some objects to have a more restrictive
policy.

Note that we will want to create a DNS CNAME and rename the S3 bucket at some point to get the full effect, but this feels like a useful first step.

[1]: alphagov/asset-manager#112
[2]: https://github.com/alphagov/asset-manager/blob/master/README.md#assets-on-s3