### PR TITLE
Make Terraform state S3 bucket configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,14 @@ Please note this is still experimental.
    thing.
 
 7. You should now be able to run per project rake tasks as required.
+
+# Development
+
+If you don't have access to the GOV.UK S3 buckets which store Terraform state for the various environments, but you want to run the standard Rake tasks to plan/apply changes, you'll need to manually create an S3 bucket (with the appropriate environment suffix, e.g. "-test") and an IAM admin user and then set the following environment variables:
+
+    TERRAFORM_STATE_S3_BUCKET_REGION=<s3-bucket-region>
+    TERRAFORM_STATE_S3_BUCKET_NAME_PREFIX=<s3-bucket-name-prefix>
+
+Here's an example of running one of the Rake tasks assuming we have a bucket named "my-s3-bucket-test" in the "eu-west-2" region:
+
+    $ TERRAFORM_STATE_S3_BUCKET_REGION=eu-west-2 TERRAFORM_STATE_S3_BUCKET_NAME_PREFIX=my-s3-bucket  PROJECT_NAME=<project-name> DEPLOY_ENV=test bundle exec rake plan

--- a/Rakefile
+++ b/Rakefile
@@ -97,8 +97,9 @@ end
 
 desc 'Configure the remote state location'
 task configure_s3_state: [:validate_environment, :purge_remote_state] do
-  region      = 'eu-west-1'
-  bucket_name = "govuk-terraform-state-#{deploy_env}"
+  region = ENV.fetch('TERRAFORM_STATE_S3_BUCKET_REGION', 'eu-west-1')
+  bucket_name_prefix = ENV.fetch('TERRAFORM_STATE_S3_BUCKET_NAME_PREFIX', "govuk-terraform-state")
+  bucket_name = "#{bucket_name_prefix}-#{deploy_env}"
 
   # workaround until we can move everything in to project based layout
   key_name = project_name.empty? ? 'terraform.tfstate' : "terraform-#{project_name}.tfstate"


### PR DESCRIPTION
These changes allow you to run the standard Rake tasks to plan/apply changes even if you don't have access to the GOV.UK S3 buckets which store Terraform state for the various environments by using your own S3 buckets.

This isn't necessarily the best way to solve this problem, because the Terraform state S3 bucket name is hard-coded elsewhere in the repo. However, given that we understand that this repo is likely to disappear in the near future, it feels like a pragmatic solution to the problem we were having.