### PR TITLE
Add S3:ListBucket permission to asset-manager IAM user

### DIFF
--- a/projects/asset-manager/resources/users.tf
+++ b/projects/asset-manager/resources/users.tf
@@ -13,6 +13,15 @@ data "aws_iam_policy_document" "asset-manager" {
       "arn:aws:s3:::${var.bucket_name}-${var.environment}/*"
     ]
   }
+
+  statement {
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.bucket_name}-${var.environment}"
+    ]
+  }
 }
 
 resource "aws_iam_policy" "asset-manager" {


### PR DESCRIPTION
Adding this permission means that we receive a 404 (Not Found) response
instead of a 403 (Permission Denied) response if the IAM user requests
an object that doesn't exist.

We're currently changing asset-manager so that it can serve asset
requests by proxying to S3. We want the external HTTP behaviour to
remain constant irrespective of whether the asset is served from the
file system or from S3. This change means that requesting an asset that
doesn't exist on S3 will now respond with a 404, which is the same
response we'd see if we were to request an asset that didn't exist on
the filesystem.

I've tested this change in our GFR AWS account and can confirm that it
works as expected.