### PR TITLE
Configure AWS lambda for public API tracking

### DIFF
--- a/projects/analytics_lambdas/main.tf
+++ b/projects/analytics_lambdas/main.tf
@@ -1,0 +1,57 @@
+resource "aws_s3_bucket" "bucket" {
+  bucket = "${var.s3_bucket}"
+
+  tags {
+    Environment = "${var.environment}"
+    Team = "Performance"
+  }
+}
+
+# IAM Role for Lambda function
+resource "aws_iam_role" "lambda_role" {
+    name = "send_public_api_events_to_ga_lambda"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_permission" "allow_bucket" {
+  statement_id  = "AllowExecutionFromS3Bucket"
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.func.arn}"
+  principal     = "s3.amazonaws.com"
+  source_arn    = "${aws_s3_bucket.bucket.arn}"
+}
+
+# AWS Lambda function
+resource "aws_lambda_function" "func" {
+    filename = "${lambda_artefact_name}"
+    function_name = "${var.lambda_function_name}"
+    role = "${aws_iam_role.lambda_role.arn}"
+    handler = "${var.lambda_handler}"
+    runtime = "${var.lambda_runtime}"
+    timeout = "${var.lambda_timeout}"
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  bucket = "${aws_s3_bucket.bucket.id}"
+
+  lambda_function {
+    lambda_function_arn = "${aws_lambda_function.func.arn}"
+    events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "${var.public_api_logs_prefix}"
+    filter_suffix       = "${var.public_api_logs_suffix}"
+  }
+}

--- a/projects/analytics_lambdas/main.tf
+++ b/projects/analytics_lambdas/main.tf
@@ -26,6 +26,28 @@ resource "aws_iam_role" "lambda_role" {
 }
 EOF
 }
+data "aws_iam_policy_document" "s3-access-ro" {
+    statement {
+        actions = [
+            "s3:GetObject",
+            "s3:ListBucket",
+        ]
+        resources = [
+            "arn:aws:s3:::*",
+        ]
+    }
+}
+
+resource "aws_iam_policy" "s3-access-ro" {
+    name = "s3-access-ro"
+    path = "${var.public_api_logs_prefix}"
+    policy = "${data.aws_iam_policy_document.s3-access-ro.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "s3-access-ro" {
+    role       = "${aws_iam_role.lamda_role.name}"
+    policy_arn = "${aws_iam_policy.s3-access-ro.arn}"
+}
 
 resource "aws_lambda_permission" "allow_bucket" {
   statement_id  = "AllowExecutionFromS3Bucket"

--- a/projects/analytics_lambdas/main.tf
+++ b/projects/analytics_lambdas/main.tf
@@ -1,16 +1,7 @@
-resource "aws_s3_bucket" "bucket" {
-  bucket = "${var.s3_bucket}"
-
-  tags {
-    Environment = "${var.environment}"
-    Team = "Performance"
-  }
-}
-
 # IAM Role for Lambda function
 resource "aws_iam_role" "lambda_role" {
-    name = "send_public_api_events_to_ga_lambda"
-    assume_role_policy = <<EOF
+  name = "send_public_api_events_to_ga_lambda"
+  assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -27,26 +18,26 @@ resource "aws_iam_role" "lambda_role" {
 EOF
 }
 data "aws_iam_policy_document" "s3-access-ro" {
-    statement {
-        actions = [
-            "s3:GetObject",
-            "s3:ListBucket",
-        ]
-        resources = [
-            "arn:aws:s3:::*",
-        ]
-    }
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
 }
 
 resource "aws_iam_policy" "s3-access-ro" {
-    name = "s3-access-ro"
-    path = "${var.public_api_logs_prefix}"
-    policy = "${data.aws_iam_policy_document.s3-access-ro.json}"
+  name = "s3-access-ro"
+  path = "${var.public_api_logs_prefix}"
+  policy = "${data.aws_iam_policy_document.s3-access-ro.json}"
 }
 
 resource "aws_iam_role_policy_attachment" "s3-access-ro" {
-    role       = "${aws_iam_role.lamda_role.name}"
-    policy_arn = "${aws_iam_policy.s3-access-ro.arn}"
+  role       = "${aws_iam_role.lambda_role.name}"
+  policy_arn = "${aws_iam_policy.s3-access-ro.arn}"
 }
 
 resource "aws_lambda_permission" "allow_bucket" {
@@ -54,21 +45,21 @@ resource "aws_lambda_permission" "allow_bucket" {
   action        = "lambda:InvokeFunction"
   function_name = "${aws_lambda_function.func.arn}"
   principal     = "s3.amazonaws.com"
-  source_arn    = "${aws_s3_bucket.bucket.arn}"
+  source_arn    = "${var.s3_bucket_id}"
 }
 
 # AWS Lambda function
 resource "aws_lambda_function" "func" {
-    filename = "${lambda_artefact_name}"
-    function_name = "${var.lambda_function_name}"
-    role = "${aws_iam_role.lambda_role.arn}"
-    handler = "${var.lambda_handler}"
-    runtime = "${var.lambda_runtime}"
-    timeout = "${var.lambda_timeout}"
+  filename = "${lambda_artefact_name}"
+  function_name = "${var.lambda_function_name}"
+  role = "${aws_iam_role.lambda_role.arn}"
+  handler = "${var.lambda_handler}"
+  runtime = "${var.lambda_runtime}"
+  timeout = "${var.lambda_timeout}"
 }
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = "${var.s3_bucket_id}"
 
   lambda_function {
     lambda_function_arn = "${aws_lambda_function.func.arn}"

--- a/projects/analytics_lambdas/variables.tf
+++ b/projects/analytics_lambdas/variables.tf
@@ -1,0 +1,24 @@
+variable "s3_bucket" {
+  default = "govuk-analytics-logs-production"
+}
+variable "public_api_logs_prefix" {
+  default = "public_api_logs/"
+}
+variable "public_api_logs_suffix" {
+  default = ".log.gz"
+}
+variable "lambda_function_name" {
+  default = "SendPublicApiEventsToGA"
+}
+variable "lambda_artefact_name" {
+  default = "send_public_api_events_to_ga_lambda.zip"
+}
+variable "lambda_handler" {
+  default = "send_public_api_events_to_ga.handle_lambda"
+}
+variable "lambda_runtime" {
+  default = "python3.6"
+}
+variable "lambda_timeout" {
+  default = 30
+}

--- a/projects/analytics_lambdas/variables.tf
+++ b/projects/analytics_lambdas/variables.tf
@@ -1,5 +1,5 @@
-variable "s3_bucket" {
-  default = "govuk-analytics-logs-production"
+variable "s3_bucket_id" {
+  default = "arn:aws:s3:::govuk-analytics-logs-production"
 }
 variable "public_api_logs_prefix" {
   default = "public_api_logs/"


### PR DESCRIPTION
Part of https://trello.com/c/nbpTiCbi/1102-publish-aws-lambda-to-process-public-api-logs

Terraform AWS configuration for lambda function to track public API request logs on S3.
The bucket config is already done [here](https://github.com/alphagov/govuk-terraform-provisioning/blob/master/projects/analytics_logging/resources/bucket_and_access.tf).

This config should give the lambda read access to the named S3 bucket and allow the lambda to execute from the bucket.

See https://github.com/alphagov/govuk-lambda-app-deployment/pull/10 and https://github.com/alphagov/govuk-lambda-app-deployment/pull/11 for lambda code + deployment.