### PR TITLE
Prepare to enable cross-region replication on production Asset Manager S3 bucket

### DIFF
--- a/projects/asset-manager/resources/policies.tf
+++ b/projects/asset-manager/resources/policies.tf
@@ -1,0 +1,27 @@
+data "aws_iam_policy_document" "asset-manager" {
+  statement {
+    sid = "1"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.bucket_name}-${var.environment}/*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.bucket_name}-${var.environment}"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "asset-manager" {
+  name = "asset-manager-user-iam-policy"
+  path = "/"
+  policy = "${data.aws_iam_policy_document.asset-manager.json}"
+}

--- a/projects/asset-manager/resources/production/buckets.tf
+++ b/projects/asset-manager/resources/production/buckets.tf
@@ -1,0 +1,4 @@
+resource "aws_s3_bucket" "asset-manager" {
+  bucket = "${var.bucket_name}-${var.environment}"
+  acl = "private"
+}

--- a/projects/asset-manager/resources/production/buckets.tf
+++ b/projects/asset-manager/resources/production/buckets.tf
@@ -1,4 +1,8 @@
 resource "aws_s3_bucket" "asset-manager" {
   bucket = "${var.bucket_name}-${var.environment}"
   acl = "private"
+
+  versioning {
+    enabled = true
+  }
 }

--- a/projects/asset-manager/resources/production/buckets_for_backups.tf
+++ b/projects/asset-manager/resources/production/buckets_for_backups.tf
@@ -3,4 +3,8 @@ resource "aws_s3_bucket" "asset-manager-backup" {
   bucket = "${var.bucket_name}-backup-${var.environment}"
   acl = "private"
   region = "${var.aws_region_for_backups}"
+
+  versioning {
+    enabled = true
+  }
 }

--- a/projects/asset-manager/resources/production/buckets_for_backups.tf
+++ b/projects/asset-manager/resources/production/buckets_for_backups.tf
@@ -1,0 +1,6 @@
+resource "aws_s3_bucket" "asset-manager-backup" {
+  provider = "aws.provider-for-backups"
+  bucket = "${var.bucket_name}-backup-${var.environment}"
+  acl = "private"
+  region = "${var.aws_region_for_backups}"
+}

--- a/projects/asset-manager/resources/production/policies_for_backups.tf
+++ b/projects/asset-manager/resources/production/policies_for_backups.tf
@@ -1,0 +1,39 @@
+resource "aws_iam_policy" "asset-manager-backup" {
+  name = "asset-manager-backup-iam-policy"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetReplicationConfiguration",
+        "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${var.bucket_name}-${var.environment}"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetObjectVersion",
+        "s3:GetObjectVersionAcl"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${var.bucket_name}-${var.environment}/*"
+      ]
+    },
+    {
+      "Action": [
+        "s3:ReplicateObject",
+        "s3:ReplicateDelete"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::${var.bucket_name}-backup-${var.environment}/*"
+    }
+  ]
+}
+POLICY
+}

--- a/projects/asset-manager/resources/production/providers_for_backups.tf
+++ b/projects/asset-manager/resources/production/providers_for_backups.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region = "${var.aws_region_for_backups}"
+  alias  = "provider-for-backups"
+}

--- a/projects/asset-manager/resources/production/roles_for_backups.tf
+++ b/projects/asset-manager/resources/production/roles_for_backups.tf
@@ -1,0 +1,25 @@
+resource "aws_iam_role" "asset-manager-backup" {
+  name = "asset-manager-backup-iam-role"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "s3.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_policy_attachment" "asset-manager-backup" {
+  name       = "asset-manager-backup-iam-policy-attachment"
+  roles      = ["${aws_iam_role.asset-manager-backup.name}"]
+  policy_arn = "${aws_iam_policy.asset-manager-backup.arn}"
+}

--- a/projects/asset-manager/resources/users.tf
+++ b/projects/asset-manager/resources/users.tf
@@ -2,34 +2,6 @@ resource "aws_iam_user" "asset-manager" {
   name = "${var.bucket_name}-${var.environment}-user"
 }
 
-data "aws_iam_policy_document" "asset-manager" {
-  statement {
-    sid = "1"
-    actions = [
-      "s3:GetObject",
-      "s3:PutObject"
-    ]
-    resources = [
-      "arn:aws:s3:::${var.bucket_name}-${var.environment}/*"
-    ]
-  }
-
-  statement {
-    actions = [
-      "s3:ListBucket"
-    ]
-    resources = [
-      "arn:aws:s3:::${var.bucket_name}-${var.environment}"
-    ]
-  }
-}
-
-resource "aws_iam_policy" "asset-manager" {
-  name = "asset-manager-user-iam-policy"
-  path = "/"
-  policy = "${data.aws_iam_policy_document.asset-manager.json}"
-}
-
 resource "aws_iam_policy_attachment" "asset-manager" {
   name = "asset-manager-user-iam-policy-attachment"
   users = ["${aws_iam_user.asset-manager.name}"]

--- a/projects/asset-manager/resources/variables.tf
+++ b/projects/asset-manager/resources/variables.tf
@@ -2,3 +2,8 @@ variable "bucket_name" {
   type    = "string"
   default = "govuk-assets"
 }
+
+variable "aws_region_for_backups" {
+  type    = "string"
+  default = "eu-west-2"
+}


### PR DESCRIPTION
This creates a new backup S3 bucket in a different region in preparation for enabling cross-region replication on the main S3 bucket currently used by the Asset Manager app.

The motivation behind this is to (eventually) replace the nightly cron job which uses Duplicity to backup the Asset Manager files from NFS to one of the off-site backup S3 buckets. This will be a step towards being able to decommission NFS, or at least the Asset Manager bit of it.

Note that this PR does *not* include actually enabling replication, because there was an ordering problem with switching on versioning on the main bucket and enabling replication. I've opened [a 2nd PR][2] to actually enable replication making use of all the resources created and modified by the changes in this PR. I plan to explain how I tested the changes in this PR in the description of the 2nd PR.

Note also that these changes are closely based on the [S3 cross-region replication example in the Terraform documentation][1].

See alphagov/asset-manager#146 for more details.

[1]: https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#using-replication-configuration
[2]: https://github.com/alphagov/govuk-terraform-provisioning/pull/141
