### PR TITLE
Create bucket for rummager-elasticsearch-snapshots

### DIFF
--- a/modules/private_s3_bucket/main.tf
+++ b/modules/private_s3_bucket/main.tf
@@ -24,6 +24,11 @@ variable "lifecycle" {
     default = "false"
 }
 
+variable "days_to_keep" {
+    type    = "string"
+    default = 30
+}
+
 
 resource "template_file" "readwrite_policy_file" {
   template = "${file("${path.module}/templates/readwrite_policy.tpl")}"
@@ -52,16 +57,8 @@ resource "aws_s3_bucket" "bucket" {
         prefix = ""
         enabled = "${var.lifecycle}"
 
-        transition {
-            days = 30
-            storage_class = "STANDARD_IA"
-        }
-        transition {
-            days = 60
-            storage_class = "GLACIER"
-        }
         expiration {
-            days = 90
+            days = "${var.days_to_keep}"
         }
     }
 }

--- a/projects/rummager-elasticsearch-snapshots/README.md
+++ b/projects/rummager-elasticsearch-snapshots/README.md
@@ -1,0 +1,3 @@
+# Rummager Elasticsearch Snapshots
+
+Creates a bucket and user to allow Rummager Elasticsearch backup snapshots.

--- a/projects/rummager-elasticsearch-snapshots/resources/main.tf
+++ b/projects/rummager-elasticsearch-snapshots/resources/main.tf
@@ -1,0 +1,11 @@
+module "rummager-elasticsearch-snapshots" {
+    source = "../../../modules/private_s3_bucket"
+
+    bucket_name  = "govuk-rummager-elasticsearch-snapshots"
+    environment  = "${var.environment}"
+    team         = "Infrastructure"
+    username     = "govuk-rummager-elasticsearch-snapshots"
+    versioning   = "true"
+    lifecycle    = "true"
+    days_to_keep = 7
+}


### PR DESCRIPTION
This uses the module we used to use extensively to create a private S3 bucket and user. I can see no reason not to use this module, and have added a variable so we can set the lifecycle expiration in days.

After some discussion, we decided we should only keep 7 days worth of snapshots as it's extremely unlikely we would require anything historical.