### PR TITLE
Allow syncing of assets between environments

### DIFF
--- a/projects/asset-manager/resources/buckets.tf
+++ b/projects/asset-manager/resources/buckets.tf
@@ -2,3 +2,8 @@ resource "aws_s3_bucket" "asset-manager" {
   bucket = "${var.bucket_name}-${var.environment}"
   acl = "private"
 }
+
+resource "aws_s3_bucket_policy" "asset-manager-env-sync-bucket" {
+  bucket = "${aws_s3_bucket.asset-manager.id}"
+  policy = "${data.aws_iam_policy_document.asset-manager-env-sync-bucket.json}"
+}

--- a/projects/asset-manager/resources/policies_for_env_sync_bucket.tf
+++ b/projects/asset-manager/resources/policies_for_env_sync_bucket.tf
@@ -1,0 +1,33 @@
+data "aws_iam_policy_document" "asset-manager-env-sync-bucket" {
+  statement {
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      "arn:aws:s3:::${var.bucket_name}-${var.environment}"
+    ]
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${var.production_aws_account_id}:user/${var.bucket_name}-production-env-sync-user",
+      ]
+    }
+  }
+
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = [
+      "arn:aws:s3:::${var.bucket_name}-${var.environment}/*"
+    ]
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${var.production_aws_account_id}:user/${var.bucket_name}-production-env-sync-user",
+      ]
+    }
+  }
+}

--- a/projects/asset-manager/resources/production/policies_for_env_sync_user.tf
+++ b/projects/asset-manager/resources/production/policies_for_env_sync_user.tf
@@ -1,0 +1,47 @@
+data "aws_iam_policy_document" "asset-manager-env-sync-user" {
+  statement {
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.bucket_name}-production"
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:GetObject"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.bucket_name}-production/*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.bucket_name}-integration",
+      "arn:aws:s3:::${var.bucket_name}-staging"
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.bucket_name}-integration/*",
+      "arn:aws:s3:::${var.bucket_name}-staging/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "asset-manager-env-sync-user" {
+  name = "asset-manager-env-sync-user-policy"
+  path = "/"
+  policy = "${data.aws_iam_policy_document.asset-manager-env-sync-user.json}"
+}

--- a/projects/asset-manager/resources/production/users_for_env_sync.tf
+++ b/projects/asset-manager/resources/production/users_for_env_sync.tf
@@ -1,0 +1,9 @@
+resource "aws_iam_user" "asset-manager-env-sync" {
+  name = "${var.bucket_name}-${var.environment}-env-sync-user"
+}
+
+resource "aws_iam_policy_attachment" "asset-manager-env-sync" {
+  name = "asset-manager-env-sync-iam-policy-attachment"
+  users = ["${aws_iam_user.asset-manager-env-sync.name}"]
+  policy_arn = "${aws_iam_policy.asset-manager-env-sync-user.arn}"
+}

--- a/projects/asset-manager/resources/variables.tf
+++ b/projects/asset-manager/resources/variables.tf
@@ -7,3 +7,8 @@ variable "aws_region_for_backups" {
   type    = "string"
   default = "eu-west-2"
 }
+
+variable "production_aws_account_id" {
+  type = "string"
+  description = "AWS account ID for production environment"
+}


### PR DESCRIPTION
The idea is that a new job in the `env-sync-and-backup` repo will SSH onto a production machine and use the `aws s3 sync` command line tool to perform a nightly sync of the production assets S3 bucket to the staging & integration assets S3 buckets.

* Adds a new IAM user to the Asset Manager project in the production environment with minimal read access to the production assets S3 bucket and minimal write access to the staging & integration assets S3 buckets.

* Adds a bucket policy to the staging & integration assets S3 buckets to allow minimal write access to the new production IAM user mentioned above.

* Note that, because each Terraform environment has its own separate AWS account, we need to pass in the AWS account ID as a Terraform variable, `production_aws_account_id`, in order to be able to construct the bucket policy mentioned above.

* Note also that we will need to generate credentials for the new IAM user (`govuk-assets-production-env-sync-user`) and make them available in the secret hieradata as:
  * `govuk::apps::asset_env_sync::aws_access_key_id`
  * `govuk::apps::asset_env_sync::aws_secret_access_key`

See alphagov/asset-manager#145 for more details.

I tested this as follows:

1. Use the `asset-manager` project in this repo to apply the integration environment state from the `master` branch to AWS account 1 from scratch
2. Use the `asset-manager` project in this repo to apply the changes in the integration environment state from the `allow-syncing-of-assets-between-environments` branch to AWS account 1
3. Use the `asset-manager` project in this repo to apply the production environment state from the `master` branch to AWS account 2 from scratch
4. Use the `asset-manager` project in this repo to apply the changes in the production environment state from the `allow-syncing-of-assets-between-environments` branch to AWS account 2
5. Add credentials to the new IAM user, `govuk-assets-production-env-sync-user`
6. Use those credentials to run the following AWS CLI command `aws s3 sync --delete s3://<production-bucket-name> s3://<integration-bucket-name>`
7. Check that objects added/renamed/removed to/in/from the production bucket are added/renamed/removed to/in/from the integration bucket when the sync command is run

Note that the S3 object data is transferred directly between the buckets - it is not downloaded to the host where the sync command is run and then uploaded to the other bucket.

See alphagov/govuk-puppet#6763 for the related changes to the Puppet configuration.

See alphagov/env-sync-and-backup#34 for the related changes to the environment syncing repo.

/cc @danielroseman, @stephenharker 