### PR TITLE
Give the 2ndline user more permissions

### DIFF
--- a/projects/user_management/resources/groups.tf
+++ b/projects/user_management/resources/groups.tf
@@ -174,6 +174,14 @@ resource "aws_iam_policy" "2ndline_policy" {
     "Version": "2012-10-17",
     "Statement": [
         {
+            "Action": [
+                "iam:GetUser",
+                "iam:GetPolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": *
+        },
+        {
             "Action": [ "s3:*" ],
             "Effect": "Allow",
             "Resource": [


### PR DESCRIPTION
- When trying to deploy asset-manager changes, it failed on not having
  access to `GetUser` and `GetPolicy`. I don't know if it'll need more
  permissions, but we can add them if it does.