### PR TITLE
Allow asset-manager to delete objects

### DIFF
--- a/projects/asset-manager/resources/policies.tf
+++ b/projects/asset-manager/resources/policies.tf
@@ -3,7 +3,8 @@ data "aws_iam_policy_document" "asset-manager" {
     sid = "1"
     actions = [
       "s3:GetObject",
-      "s3:PutObject"
+      "s3:PutObject",
+      "s3:DeleteObject"
     ]
     resources = [
       "arn:aws:s3:::${var.bucket_name}-${var.environment}/*"


### PR DESCRIPTION
This allows new Rake tasks which make it easier to delete assets off S3.

[Trello Card](https://trello.com/c/bod2J0d5/393-make-the-process-of-deleting-assets-off-s3-easier)